### PR TITLE
fix inconsistent license declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple list prompt UI for the terminal for Haskell.
 ![screenshot](/screenshot.png)
 
 ## License
-This code is licensed under the GPLv3 license for Pedro Tacla Yamada. For more
+This code is licensed under the GPLv2+ license for Pedro Tacla Yamada. For more
 information, please refer to the [LICENSE](/LICENSE) file.
 
 ## Donations


### PR DESCRIPTION
The cabal file and the LICENSE file both say it's GPL version 2 or later.